### PR TITLE
Feature/trailing border color

### DIFF
--- a/lib/src/animated_loading_border_widget.dart
+++ b/lib/src/animated_loading_border_widget.dart
@@ -34,8 +34,8 @@ class AnimatedLoadingBorder extends StatefulWidget {
   final Color borderColor;
 
   /// Defines the color for the trailing part of the border
-  /// Default value [Colors.black]
-  final Color trailingBorderColor;
+  /// Default value [borderColor.withOpacity(0)]
+  final Color? trailingBorderColor;
 
   /// Used to add child widget padding
   /// Default value [EdgeInsets.zero]
@@ -45,10 +45,6 @@ class AnimatedLoadingBorder extends StatefulWidget {
   /// Default value [true]
   final bool startWithRandomPosition;
 
-  /// Used to set starting color of SweepGradient
-  /// Default value [true]
-  final bool isTrailingTransparent;
-
   const AnimatedLoadingBorder({
     required this.child,
     this.controller,
@@ -57,10 +53,9 @@ class AnimatedLoadingBorder extends StatefulWidget {
     this.borderWidth = 1,
     this.borderLength = 0.2,
     this.borderColor = Colors.black,
-    this.trailingBorderColor = Colors.black,
+    this.trailingBorderColor,
     this.padding = EdgeInsets.zero,
     this.startWithRandomPosition = true,
-    this.isTrailingTransparent = true,
     Key? key,
   }) : super(key: key);
 
@@ -130,8 +125,8 @@ class _AnimatedLoadingBorderState extends State<AnimatedLoadingBorder>
         borderWidth: widget.borderWidth,
         gradientLength: widget.borderLength,
         borderColor: borderColor,
-        trailingBorderColor: widget.trailingBorderColor,
-        isTrailingTransparent: widget.isTrailingTransparent,
+        trailingBorderColor: widget.trailingBorderColor
+            ?? borderColor.withOpacity(0),
         startingPosition:
             widget.startWithRandomPosition ? getRandomNumber() : 0,
       ),

--- a/lib/src/border_painter.dart
+++ b/lib/src/border_painter.dart
@@ -44,6 +44,7 @@ class BorderPainter extends CustomPainter {
     final progress = animation.value;
 
     if (progress > 0.0) {
+      paint.color = borderColor;
       paint.shader = SweepGradient(
         colors: [
           trailingBorderColor,

--- a/lib/src/border_painter.dart
+++ b/lib/src/border_painter.dart
@@ -23,9 +23,6 @@ class BorderPainter extends CustomPainter {
   /// Color for the trailing part of the border
   final Color trailingBorderColor;
 
-  /// Used to set starting color of SweepGradient
-  final bool isTrailingTransparent;
-
   /// Starting position used in SweepGradient
   final int startingPosition;
 
@@ -36,7 +33,6 @@ class BorderPainter extends CustomPainter {
     required this.gradientLength,
     required this.borderColor,
     required this.trailingBorderColor,
-    required this.isTrailingTransparent,
     required this.startingPosition,
   }) : super(repaint: animation);
 
@@ -48,12 +44,9 @@ class BorderPainter extends CustomPainter {
     final progress = animation.value;
 
     if (progress > 0.0) {
-      paint.color = trailingBorderColor;
       paint.shader = SweepGradient(
         colors: [
-          isTrailingTransparent
-              ? Colors.transparent
-              : borderColor.withOpacity(0.1),
+          trailingBorderColor,
           borderColor,
           Colors.transparent,
         ],


### PR DESCRIPTION
Re-implements trailingBorderColor

- Fixing the usage of this parameter (that was not doing anything previously)

Removes isTrailingTransparent parameter

- Increasing the possibilities of customisation
- Getting rid of Colors.transparent as an ending color of the gradient, which is never computing well in Flutter